### PR TITLE
Add light/dark theme switcher

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
-<footer class="bg-gray-800 text-white py-8">
+<footer class="bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white py-8">
     <div class="max-w-6xl mx-auto px-6 lg:px-12 text-center">
-        <p class="text-gray-400">© 2025 Alexandre Petitjean - Expert Django & DevOps</p>
+        <p class="text-gray-600 dark:text-gray-400">© 2025 Alexandre Petitjean - Expert Django & DevOps</p>
     </div>
 </footer> 

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,5 +1,5 @@
 <!-- Navigation -->
-<nav class="fixed top-0 w-full bg-gradient-to-r from-gray-900/95 via-gray-800/95 to-primary-900/95 backdrop-blur-md border-b border-primary-500/20 z-50">
+<nav class="fixed top-0 w-full bg-white/90 dark:bg-gradient-to-r dark:from-gray-900/95 dark:via-gray-800/95 dark:to-primary-900/95 backdrop-blur-md border-b border-primary-500/20">
     <!-- Background Pattern -->
     <div class="absolute inset-0 opacity-5">
         <div class="absolute inset-0 bg-white/5" style="background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.15) 1px, transparent 0); background-size: 20px 20px;"></div>
@@ -14,7 +14,7 @@
             
             <!-- Navigation Links -->
             <div class="hidden md:flex items-center space-x-8 text-sm">
-                <a href="#hero" class="relative text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
+                <a href="#hero" class="relative text-gray-700 dark:text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
                     <!-- Home Icon -->
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
@@ -22,7 +22,7 @@
                     <span>Accueil</span>
                     <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-primary-400 to-primary-200 group-hover:w-full transition-all duration-200"></span>
                 </a>
-                <a href="#offers" class="relative text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
+                <a href="#offers" class="relative text-gray-700 dark:text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
                     <!-- Briefcase Icon -->
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4a2 2 0 00-2-2H8a2 2 0 00-2 2v2m8 0V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m8 0h3a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h3"/>
@@ -30,7 +30,7 @@
                     <span>Services</span>
                     <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-primary-400 to-primary-200 group-hover:w-full transition-all duration-200"></span>
                 </a>
-                <a href="#skills" class="relative text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
+                <a href="#skills" class="relative text-gray-700 dark:text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
                     <!-- Academic Cap Icon -->
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5z"/>
@@ -40,7 +40,7 @@
                     <span>Compétences</span>
                     <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-primary-400 to-primary-200 group-hover:w-full transition-all duration-200"></span>
                 </a>
-                <a href="#projets" class="relative text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
+                <a href="#projets" class="relative text-gray-700 dark:text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
                     <!-- Code Icon -->
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
@@ -48,7 +48,7 @@
                     <span>Projets</span>
                     <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-primary-400 to-primary-200 group-hover:w-full transition-all duration-200"></span>
                 </a>
-                <a href="#about" class="relative text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
+                <a href="#about" class="relative text-gray-700 dark:text-white/90 hover:text-primary-400 transition-all duration-200 group flex items-center space-x-2">
                     <!-- User Icon -->
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
@@ -57,9 +57,21 @@
                     <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-primary-400 to-primary-200 group-hover:w-full transition-all duration-200"></span>
                 </a>
                 
+                <!-- Thème toggle -->
+                <button id="theme-toggle" class="p-2 rounded hover:text-primary-400 text-gray-700 dark:text-white/90">
+                    <!-- Sun Icon -->
+                    <svg id="icon-sun" class="w-5 h-5 hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707m12.728 0l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <!-- Moon Icon -->
+                    <svg id="icon-moon" class="w-5 h-5 hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+                    </svg>
+                </button>
+
                 <!-- Délimiteur vertical -->
                 <div class="w-px h-6 bg-gradient-to-b from-transparent via-primary-400/50 to-transparent"></div>
-                
+
                 <!-- Bouton Contact CTA -->
                 <a href="#contact" class="group relative inline-flex items-center justify-center px-4 py-2 font-medium text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
                     <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-0.5 translate-y-0.5 bg-primary-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
@@ -76,7 +88,7 @@
             
             <!-- Mobile menu button -->
             <div class="md:hidden">
-                <button class="text-white/90 hover:text-primary-400 transition-colors p-2">
+                <button class="text-gray-700 dark:text-white/90 hover:text-primary-400 transition-colors p-2">
                     <!-- Bars 3 Icon -->
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
@@ -85,4 +97,22 @@
             </div>
         </div>
     </div>
-</nav> 
+</nav>
+
+<script>
+  const toggle = document.getElementById('theme-toggle');
+  const iconSun = document.getElementById('icon-sun');
+  const iconMoon = document.getElementById('icon-moon');
+  function updateIcons() {
+    const isDark = document.documentElement.classList.contains('dark');
+    iconSun.classList.toggle('hidden', !isDark);
+    iconMoon.classList.toggle('hidden', isDark);
+  }
+  updateIcons();
+  toggle.addEventListener('click', () => {
+    const html = document.documentElement;
+    const isDark = html.classList.toggle('dark');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    updateIcons();
+  });
+</script>

--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -7,53 +7,53 @@
     <div class="relative max-w-screen-2xl mx-auto px-6 lg:px-12 py-20 w-full">
         <!-- Section Header -->
         <div class="text-center mb-16">
-            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-white">
+            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
                 À 
                 <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">
                     propos
                 </span>
             </h2>
-            <p class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+            <p class="text-xl text-gray-700 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
                 Développeur backend passionné par les solutions robustes et scalables
             </p>
         </div>
 
         <!-- About Content -->
-        <div class="relative bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl p-8 lg:p-12 hover:border-primary-400/40 transition-all duration-300">
+        <div class="relative bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl p-8 lg:p-12 hover:border-primary-400/40 transition-all duration-300">
             <div class="absolute inset-0 bg-gradient-to-br from-primary-500/5 to-transparent rounded-3xl"></div>
             <div class="relative">
                 <div class="prose prose-lg max-w-none">
-                    <p class="text-gray-300 leading-relaxed mb-8 text-lg">
+                    <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-8 text-lg">
                         <span class="text-primary-400 font-semibold">Développeur backend indépendant</span> spécialisé en 
                         <span class="text-primary-300 font-medium">Django depuis plus de 5 ans</span>,
                         mon expertise couvre l'intégralité du cycle de vie d'une application :
-                        <span class="text-white font-medium">architecture, développement, CI/CD, mise en production et supervision</span>.
+                        <span class="text-gray-900 dark:text-white font-medium">architecture, développement, CI/CD, mise en production et supervision</span>.
                     </p>
-                    <p class="text-gray-300 leading-relaxed mb-8 text-lg">
+                    <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-8 text-lg">
                         Je travaille avec des <span class="text-primary-300 font-medium">startups, des PME</span> et des 
-                        <span class="text-white font-medium">environnements techniques exigeants</span>.
+                        <span class="text-gray-900 dark:text-white font-medium">environnements techniques exigeants</span>.
                         Mon approche se concentre sur la production de code 
                         <span class="text-primary-400 font-semibold">maintenable, documenté, testé</span> et 
-                        <span class="text-white font-medium">prêt pour la production</span>.
+                        <span class="text-gray-900 dark:text-white font-medium">prêt pour la production</span>.
                     </p>
-                    <p class="text-gray-300 leading-relaxed text-lg">
+                    <p class="text-gray-700 dark:text-gray-300 leading-relaxed text-lg">
                         À l'aise aussi bien <span class="text-primary-300 font-medium">en équipe qu'en autonomie complète</span>, 
-                        j'aime comprendre les <span class="text-white font-medium">enjeux métier</span>
+                        j'aime comprendre les <span class="text-gray-900 dark:text-white font-medium">enjeux métier</span>
                         pour proposer des solutions techniques 
                         <span class="text-primary-400 font-semibold">pertinentes et scalables</span>.
                     </p>
                 </div>
 
                 <!-- Key Points -->
-                <div class="grid md:grid-cols-3 gap-6 mt-12 pt-8 border-t border-gray-700/30">
+                <div class="grid md:grid-cols-3 gap-6 mt-12 pt-8 border-t border-gray-300 dark:border-gray-700/30">
                     <div class="text-center">
                         <div class="w-12 h-12 bg-gradient-to-br from-primary-500/20 to-primary-600/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
                             <svg class="w-6 h-6 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                             </svg>
                         </div>
-                        <h3 class="text-lg font-semibold text-white mb-2">5+ ans d'expertise</h3>
-                        <p class="text-gray-400 text-sm">Django, Python, architectures complexes</p>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">5+ ans d'expertise</h3>
+                        <p class="text-gray-600 dark:text-gray-400 text-sm">Django, Python, architectures complexes</p>
                     </div>
                     <div class="text-center">
                         <div class="w-12 h-12 bg-gradient-to-br from-primary-500/20 to-primary-600/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
@@ -61,8 +61,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/>
                             </svg>
                         </div>
-                        <h3 class="text-lg font-semibold text-white mb-2">Code de qualité</h3>
-                        <p class="text-gray-400 text-sm">Maintenable, testé, documenté</p>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Code de qualité</h3>
+                        <p class="text-gray-600 dark:text-gray-400 text-sm">Maintenable, testé, documenté</p>
                     </div>
                     <div class="text-center">
                         <div class="w-12 h-12 bg-gradient-to-br from-primary-500/20 to-primary-600/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
@@ -70,8 +70,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"/>
                             </svg>
                         </div>
-                        <h3 class="text-lg font-semibold text-white mb-2">Solutions scalables</h3>
-                        <p class="text-gray-400 text-sm">Architecture pensée pour la croissance</p>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Solutions scalables</h3>
+                        <p class="text-gray-600 dark:text-gray-400 text-sm">Architecture pensée pour la croissance</p>
                     </div>
                 </div>
             </div>

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -7,13 +7,13 @@
     <div class="relative max-w-screen-2xl mx-auto px-6 lg:px-12 py-20 w-full">
         <!-- Section Header -->
         <div class="text-center mb-16">
-            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-white">
+            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
                 Parlons de votre 
                 <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">
                     projet
                 </span>
             </h2>
-            <p class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+            <p class="text-xl text-gray-700 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
                 Disponible pour de nouvelles missions freelance ou en régie.
                 <br class="hidden sm:block"/>
                 <span class="text-primary-300 font-medium">Je vous répondrai sous 24h.</span>
@@ -21,14 +21,14 @@
         </div>
 
         <!-- Contact Content -->
-        <div class="relative bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl p-8 lg:p-12 hover:border-primary-400/40 transition-all duration-300">
+        <div class="relative bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl p-8 lg:p-12 hover:border-primary-400/40 transition-all duration-300">
             <div class="absolute inset-0 bg-gradient-to-br from-primary-500/5 to-transparent rounded-3xl"></div>
             <div class="relative text-center">
                 
                 <!-- Contact Buttons -->
                 <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mb-12">
                     <a href="mailto:petitjean.alexandre.pro@gmail.com"
-                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
+                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-gray-900 dark:text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
                         <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-1 translate-y-1 bg-primary-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
                         <span class="absolute inset-0 w-full h-full bg-primary-600 border-2 border-primary-500 group-hover:bg-primary-500 rounded-lg"></span>
                         <span class="relative flex items-center space-x-3">
@@ -41,7 +41,7 @@
                     </a>
                     
                     <a href="https://www.linkedin.com/in/petitjeana/"
-                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900">
+                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-gray-900 dark:text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900">
                         <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-1 translate-y-1 bg-blue-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
                         <span class="absolute inset-0 w-full h-full bg-blue-600 border-2 border-blue-500 group-hover:bg-blue-500 rounded-lg"></span>
                         <span class="relative flex items-center space-x-3">
@@ -55,15 +55,15 @@
                 </div>
 
                 <!-- Additional Info -->
-                <div class="grid md:grid-cols-2 gap-8 pt-8 border-t border-gray-700/30">
+                <div class="grid md:grid-cols-2 gap-8 pt-8 border-t border-gray-300 dark:border-gray-700/30">
                     <div class="text-center">
                         <div class="w-12 h-12 bg-gradient-to-br from-primary-500/20 to-primary-600/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
                             <svg class="w-6 h-6 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
                             </svg>
                         </div>
-                        <h3 class="text-lg font-semibold text-white mb-2">Réponse rapide</h3>
-                        <p class="text-gray-400">Réponse garantie sous 24h pour toute demande de projet</p>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Réponse rapide</h3>
+                        <p class="text-gray-600 dark:text-gray-400">Réponse garantie sous 24h pour toute demande de projet</p>
                     </div>
                     <div class="text-center">
                         <div class="w-12 h-12 bg-gradient-to-br from-primary-500/20 to-primary-600/20 rounded-2xl flex items-center justify-center mx-auto mb-4">
@@ -71,8 +71,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"/>
                             </svg>
                         </div>
-                        <h3 class="text-lg font-semibold text-white mb-2">Disponibilité</h3>  
-                        <p class="text-gray-400">Missions freelance & régie - Démarrage rapide</p>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Disponibilité</h3>  
+                        <p class="text-gray-600 dark:text-gray-400">Missions freelance & régie - Démarrage rapide</p>
                     </div>
                 </div>
             </div>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -13,9 +13,9 @@ import Terminal from "../hero/Terminal.astro";
     <div class="relative max-w-screen-2xl mx-auto px-6 lg:px-12 py-20">
         <div class="grid lg:grid-cols-2 gap-12 items-center">
             <!-- Left Column -->
-            <div class="text-white space-y-8">
+            <div class="text-gray-900 dark:text-white space-y-8">
                 <!-- Status Badge -->
-                <div class="inline-flex items-center space-x-2 bg-primary-500/30 backdrop-blur-sm text-white px-4 py-2 rounded-full text-sm font-medium border border-primary-400/50">
+                <div class="inline-flex items-center space-x-2 bg-primary-500/30 backdrop-blur-sm text-gray-900 dark:text-white px-4 py-2 rounded-full text-sm font-medium border border-primary-400/50">
                     <span class="relative flex h-3 w-3">
                         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-100"></span>
                         <span class="relative inline-flex rounded-full h-3 w-3 bg-primary-300"></span>
@@ -31,7 +31,7 @@ import Terminal from "../hero/Terminal.astro";
                             Django & DevOps
                         </span>
                     </h1>
-                    <p class="text-xl text-gray-300 leading-relaxed max-w-2xl">
+                    <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed max-w-2xl">
                         Développeur fullstack indépendant, je conçois et maintiens des applications critiques 
                         prêtes pour la production avec une approche DevOps moderne.
                     </p>
@@ -40,7 +40,7 @@ import Terminal from "../hero/Terminal.astro";
                 <!-- CTA Buttons -->
                 <div class="flex flex-col sm:flex-row gap-4 pt-4">
                     <a href="#contact" 
-                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
+                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-gray-900 dark:text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
                         <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-1 translate-y-1 bg-primary-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
                         <span class="absolute inset-0 w-full h-full bg-primary-600 border-2 border-primary-500 group-hover:bg-primary-500 rounded-lg"></span>
                         <span class="relative flex items-center space-x-3">
@@ -56,9 +56,9 @@ import Terminal from "../hero/Terminal.astro";
                         </span>
                     </a>
                     <a href="#projets" 
-                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
-                        <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-1 translate-y-1 bg-gray-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
-                        <span class="absolute inset-0 w-full h-full bg-transparent border-2 border-gray-600 group-hover:border-primary-500 group-hover:bg-primary-500/10 rounded-lg"></span>
+                       class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-gray-900 dark:text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
+                        <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-1 translate-y-1 bg-gray-100 dark:bg-gray-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
+                        <span class="absolute inset-0 w-full h-full bg-transparent border-2 border-gray-300 dark:border-gray-600 group-hover:border-primary-500 group-hover:bg-primary-500/10 rounded-lg"></span>
                         <span class="relative flex items-center space-x-3 group-hover:text-primary-400 transition-colors">
                             <!-- Eye Icon -->
                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -93,7 +93,7 @@ import Terminal from "../hero/Terminal.astro";
     <!-- Scroll Indicator -->
     <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
         <!-- Chevron Down Icon -->
-        <svg class="w-6 h-6 text-white/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-6 h-6 text-gray-900 dark:text-white/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
         </svg>
     </div>

--- a/src/components/sections/Projects.astro
+++ b/src/components/sections/Projects.astro
@@ -11,13 +11,13 @@ import ProjectCard from "../ProjectCard.astro";
     <div class="relative max-w-screen-2xl mx-auto px-6 lg:px-12 py-20 w-full">
         <!-- Section Header -->
         <div class="text-center mb-16">
-            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-white">
+            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
                 Projets 
                 <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">
                     récents
                 </span>
             </h2>
-            <p class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+            <p class="text-xl text-gray-700 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
                 Applications critiques en production avec un impact métier mesurable
             </p>
         </div>
@@ -85,7 +85,7 @@ import ProjectCard from "../ProjectCard.astro";
         </div>
 
         <!-- Call to Action -->
-        <div class="relative p-8 lg:p-12 bg-gradient-to-br from-primary-900/30 to-gray-900/30 backdrop-blur-sm border border-primary-500/30 rounded-3xl text-center">
+        <div class="relative p-8 lg:p-12 bg-gradient-to-br from-primary-200/30 dark:from-primary-900/30 to-gray-200/30 dark:to-gray-900/30 backdrop-blur-sm border border-primary-500/30 rounded-3xl text-center">
             <div class="absolute inset-0 bg-gradient-to-br from-primary-500/5 to-transparent rounded-3xl"></div>
             <div class="relative">
                 <div class="flex items-center justify-center space-x-4 mb-6">
@@ -95,16 +95,16 @@ import ProjectCard from "../ProjectCard.astro";
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"/>
                         </svg>
                     </div>
-                    <h3 class="text-2xl font-bold text-white">
+                    <h3 class="text-2xl font-bold text-gray-900 dark:text-white">
                         Vous avez un 
                         <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">projet en tête ?</span>
                     </h3>
                 </div>
-                <p class="text-lg text-gray-300 leading-relaxed max-w-3xl mx-auto mb-8">
-                    Ces projets reflètent mon approche : <strong class="text-white">comprendre les enjeux métier</strong>, 
+                <p class="text-lg text-gray-700 dark:text-gray-300 leading-relaxed max-w-3xl mx-auto mb-8">
+                    Ces projets reflètent mon approche : <strong class="text-gray-900 dark:text-white">comprendre les enjeux métier</strong>, 
                     concevoir des solutions robustes et assurer une mise en production sans accroc.
                 </p>
-                <a href="#contact" class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
+                <a href="#contact" class="group relative inline-flex items-center justify-center px-8 py-4 font-bold text-gray-900 dark:text-white transition-all duration-200 ease-out rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-900">
                     <span class="absolute inset-0 w-full h-full transition duration-200 ease-out transform translate-x-1 translate-y-1 bg-primary-800 group-hover:translate-x-0 group-hover:translate-y-0 rounded-lg"></span>
                     <span class="absolute inset-0 w-full h-full bg-primary-600 border-2 border-primary-500 group-hover:bg-primary-500 rounded-lg"></span>
                     <span class="relative flex items-center space-x-3">

--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -7,13 +7,13 @@
     <div class="relative max-w-screen-2xl mx-auto px-6 lg:px-12 py-20 w-full">
         <!-- Section Header -->
         <div class="text-center mb-16">
-            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-white">
+            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
                 Ce que je 
                 <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">
                     propose
                 </span>
             </h2>
-            <p class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+            <p class="text-xl text-gray-700 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
                 Des solutions techniques adaptées à vos enjeux business avec une expertise Django et DevOps
             </p>
         </div>
@@ -21,7 +21,7 @@
         <!-- Services Grid -->
         <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-8 mb-16">
             <!-- Service 1: Développement Django -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-2xl"></div>
                 <div class="relative">
                     <!-- Cog 6 Tooth Icon -->
@@ -31,17 +31,17 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold mb-4 text-white group-hover:text-primary-300 transition-colors">
+                    <h3 class="text-xl font-bold mb-4 text-gray-900 dark:text-white group-hover:text-primary-300 transition-colors">
                         Développement Django
                     </h3>
-                    <p class="text-gray-400 leading-relaxed">
+                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
                         Applications web robustes, APIs REST performantes et intégrations complexes
                     </p>
                 </div>
             </div>
 
             <!-- Service 2: Conseil technique -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-2xl"></div>
                 <div class="relative">
                     <!-- Light Bulb Icon -->
@@ -50,17 +50,17 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"/>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold mb-4 text-white group-hover:text-primary-300 transition-colors">
+                    <h3 class="text-xl font-bold mb-4 text-gray-900 dark:text-white group-hover:text-primary-300 transition-colors">
                         Conseil technique
                     </h3>
-                    <p class="text-gray-400 leading-relaxed">
+                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
                         Architecture logicielle, clean code et résolution de dette technique
                     </p>
                 </div>
             </div>
 
             <!-- Service 3: DevOps & CI/CD -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-2xl"></div>
                 <div class="relative">
                     <!-- Rocket Launch Icon -->
@@ -69,17 +69,17 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold mb-4 text-white group-hover:text-primary-300 transition-colors">
+                    <h3 class="text-xl font-bold mb-4 text-gray-900 dark:text-white group-hover:text-primary-300 transition-colors">
                         DevOps & CI/CD
                     </h3>
-                    <p class="text-gray-400 leading-relaxed">
+                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
                         Docker, monitoring avancé et déploiements automatisés
                     </p>
                 </div>
             </div>
 
             <!-- Service 4: CTO as a Service -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-2xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-105">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-2xl"></div>
                 <div class="relative">
                     <!-- User Group Icon -->
@@ -88,10 +88,10 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"/>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold mb-4 text-white group-hover:text-primary-300 transition-colors">
+                    <h3 class="text-xl font-bold mb-4 text-gray-900 dark:text-white group-hover:text-primary-300 transition-colors">
                         CTO as a Service
                     </h3>
-                    <p class="text-gray-400 leading-relaxed">
+                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
                         Direction technique stratégique pour startups et PME
                     </p>
                 </div>
@@ -99,7 +99,7 @@
         </div>
 
         <!-- Approach Section -->
-        <div class="relative p-8 lg:p-12 bg-gradient-to-br from-primary-900/30 to-gray-900/30 backdrop-blur-sm border border-primary-500/30 rounded-3xl">
+        <div class="relative p-8 lg:p-12 bg-gradient-to-br from-primary-200/30 dark:from-primary-900/30 to-gray-200/30 dark:to-gray-900/30 backdrop-blur-sm border border-primary-500/30 rounded-3xl">
             <div class="absolute inset-0 bg-gradient-to-br from-primary-500/5 to-transparent rounded-3xl"></div>
             <div class="relative text-center">
                 <div class="w-16 h-16 mx-auto mb-6 text-primary-400">
@@ -108,12 +108,12 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                     </svg>
                 </div>
-                <h3 class="text-2xl font-bold mb-6 text-white">
+                <h3 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
                     Mon <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">approche</span>
                 </h3>
-                <p class="text-lg lg:text-xl text-gray-300 leading-relaxed max-w-4xl mx-auto">
+                <p class="text-lg lg:text-xl text-gray-700 dark:text-gray-300 leading-relaxed max-w-4xl mx-auto">
                     Je peux travailler seul ou en collaboration avec vos équipes existantes. 
-                    Mon objectif est toujours le même : <strong class="text-white">livrer du code robuste, compréhensible, 
+                    Mon objectif est toujours le même : <strong class="text-gray-900 dark:text-white">livrer du code robuste, compréhensible, 
                     bien intégré</strong> dans vos processus métier et technique.
                 </p>
             </div>

--- a/src/components/sections/Skills.astro
+++ b/src/components/sections/Skills.astro
@@ -7,13 +7,13 @@
     <div class="relative max-w-screen-2xl mx-auto px-6 lg:px-12 py-20 w-full">
         <!-- Section Header -->
         <div class="text-center mb-16">
-            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-white">
+            <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-gray-900 dark:text-white">
                 Stack 
                 <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">
                     technique
                 </span>
             </h2>
-            <p class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+            <p class="text-xl text-gray-700 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
                 Technologies maîtrisées pour vos projets critiques avec une expertise approfondie
             </p>
         </div>
@@ -21,7 +21,7 @@
         <!-- Skills Grid -->
         <div class="grid lg:grid-cols-3 gap-8">
             <!-- Backend & API -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-[1.02]">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-[1.02]">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-3xl"></div>
                 <div class="relative">
                     <!-- Header -->
@@ -32,33 +32,33 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
                             </svg>
                         </div>
-                        <h3 class="text-2xl font-bold text-white group-hover:text-primary-300 transition-colors">
+                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white group-hover:text-primary-300 transition-colors">
                             Backend & API
                         </h3>
                     </div>
 
                     <!-- Skills List -->
                     <div class="space-y-4">
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Django, Django REST Framework</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Django, Django REST Framework</span>
                             <span class="px-3 py-1 bg-primary-500/20 text-primary-300 text-sm font-semibold rounded-full border border-primary-400/30">
                                 Expert
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Python, SQL/PLSQL</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Python, SQL/PLSQL</span>
                             <span class="px-3 py-1 bg-primary-500/20 text-primary-300 text-sm font-semibold rounded-full border border-primary-400/30">
                                 Expert
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Celery, RabbitMQ, Redis</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Celery, RabbitMQ, Redis</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">PostgreSQL, MySQL/MariaDB</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">PostgreSQL, MySQL/MariaDB</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
@@ -68,7 +68,7 @@
             </div>
 
             <!-- DevOps & Infra -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-[1.02]">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-[1.02]">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-3xl"></div>
                 <div class="relative">
                     <!-- Header -->
@@ -79,33 +79,33 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z"/>
                             </svg>
                         </div>
-                        <h3 class="text-2xl font-bold text-white group-hover:text-blue-300 transition-colors">
+                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white group-hover:text-blue-300 transition-colors">
                             DevOps & Infra
                         </h3>
                     </div>
 
                     <!-- Skills List -->
                     <div class="space-y-4">
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Docker, Docker Compose</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Docker, Docker Compose</span>
                             <span class="px-3 py-1 bg-primary-500/20 text-primary-300 text-sm font-semibold rounded-full border border-primary-400/30">
                                 Expert
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">GitLab CI/CD, Jenkins</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">GitLab CI/CD, Jenkins</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Linux, monitoring</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Linux, monitoring</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Prometheus, Grafana</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Prometheus, Grafana</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
@@ -115,7 +115,7 @@
             </div>
 
             <!-- Méthodologie -->
-            <div class="group relative p-8 bg-gradient-to-br from-gray-800/50 to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-[1.02]">
+            <div class="group relative p-8 bg-gradient-to-br from-gray-100/50 dark:from-gray-800/50 to-primary-200/50 dark:to-gray-900/50 backdrop-blur-sm border border-primary-500/20 rounded-3xl hover:border-primary-400/40 transition-all duration-300 hover:transform hover:scale-[1.02]">
                 <div class="absolute inset-0 bg-gradient-to-br from-primary-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-3xl"></div>
                 <div class="relative">
                     <!-- Header -->
@@ -128,34 +128,34 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14l9-5-9-5-9 5 9 5zm0 0v6"/>
                             </svg>
                         </div>
-                        <h3 class="text-2xl font-bold text-white group-hover:text-purple-300 transition-colors">
+                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white group-hover:text-purple-300 transition-colors">
                             Méthodologie
                         </h3>
                     </div>
 
                     <!-- Skills List -->
                     <div class="space-y-4">
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Agile/Scrum, Clean Code</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Agile/Scrum, Clean Code</span>
                             <span class="px-3 py-1 bg-primary-500/20 text-primary-300 text-sm font-semibold rounded-full border border-primary-400/30">
                                 Expert
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">TDD, Documentation</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">TDD, Documentation</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Git, GitLab, PyCharm</span>
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Git, GitLab, PyCharm</span>
                             <span class="px-3 py-1 bg-blue-500/20 text-blue-300 text-sm font-semibold rounded-full border border-blue-400/30">
                                 Avancé
                             </span>
                         </div>
-                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
-                            <span class="text-gray-300 font-medium">Flutter, React</span>
-                            <span class="px-3 py-1 bg-gray-500/20 text-gray-400 text-sm font-semibold rounded-full border border-gray-400/30">
+                        <div class="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-100/30 dark:bg-gray-800/30 group-hover:bg-gray-700/30 transition-colors">
+                            <span class="text-gray-700 dark:text-gray-300 font-medium">Flutter, React</span>
+                            <span class="px-3 py-1 bg-gray-500/20 text-gray-600 dark:text-gray-400 text-sm font-semibold rounded-full border border-gray-400/30">
                                 Notions
                             </span>
                         </div>
@@ -165,7 +165,7 @@
         </div>
 
         <!-- Additional Info Section -->
-        <div class="mt-16 relative p-8 lg:p-12 bg-gradient-to-br from-primary-900/30 to-gray-900/30 backdrop-blur-sm border border-primary-500/30 rounded-3xl">
+        <div class="mt-16 relative p-8 lg:p-12 bg-gradient-to-br from-primary-200/30 dark:from-primary-900/30 to-gray-200/30 dark:to-gray-900/30 backdrop-blur-sm border border-primary-500/30 rounded-3xl">
             <div class="absolute inset-0 bg-gradient-to-br from-primary-500/5 to-transparent rounded-3xl"></div>
             <div class="relative text-center">
                 <div class="w-16 h-16 mx-auto mb-6 text-primary-400">
@@ -174,11 +174,11 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"/>
                     </svg>
                 </div>
-                <h3 class="text-2xl font-bold mb-6 text-white">
+                <h3 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
                     Expertise <span class="bg-gradient-to-r from-primary-400 to-primary-200 bg-clip-text text-transparent">approfondie</span>
                 </h3>
-                <p class="text-lg text-gray-300 leading-relaxed max-w-4xl mx-auto">
-                    <strong class="text-white">Plus de 8 ans d'expérience</strong> dans le développement d'applications critiques. 
+                <p class="text-lg text-gray-700 dark:text-gray-300 leading-relaxed max-w-4xl mx-auto">
+                    <strong class="text-gray-900 dark:text-white">Plus de 8 ans d'expérience</strong> dans le développement d'applications critiques. 
                     Je maîtrise l'ensemble de la chaîne technique, de la conception à la mise en production, 
                     en passant par l'optimisation des performances et la sécurité.
                 </p>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,8 +9,15 @@ import Footer from "../components/Footer.astro";
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Alexandre Petitjean - Expert Django & DevOps</title>
+    <script>
+      const stored = localStorage.getItem('theme');
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if(stored === 'dark' || (!stored && systemDark)) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
 </head>
-<body class="bg-gradient-to-br from-gray-900 via-gray-800 to-primary-900">
+<body>
     <Navigation />
 
     <main class="mx-auto">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,3 +13,12 @@
     --color-primary-900: #14532d;
     --color-primary-950: #052e16;
 }
+
+@layer base {
+  html {
+    @apply bg-white text-gray-900;
+  }
+  html.dark {
+    @apply bg-gradient-to-br from-gray-900 via-gray-800 to-primary-900 text-white;
+  }
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './src/**/*.{astro,html,js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config with `darkMode: 'class'`
- define base colors for light/dark themes
- initialise theme according to user preference
- add button in nav bar to toggle theme
- update component styles to support light mode

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec0c41908322a37383c78b383e9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added theme toggle button in the navigation bar, allowing users to switch between light and dark modes.
  - Theme preference is remembered across sessions.

- **Style**
  - Updated all major sections (Footer, Navigation, About, Contact, Hero, Projects, Services, Skills) to support both light and dark themes for improved readability and accessibility.
  - Enhanced background, text, and border colors to dynamically adapt based on the selected theme.

- **Chores**
  - Introduced Tailwind CSS configuration with dark mode support.
  - Added global CSS rules for consistent theming across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->